### PR TITLE
Simplify doesManPageHaveRunnableExample

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -825,35 +825,17 @@ doesManPageHaveRunnableExample <- function(rd)
     hasExamples <- any(unlist(lapply(rd,
         function(x) attr(x, "Rd_tag") == "\\examples")))
     if (!hasExamples) return(FALSE)
-    ex <- capture.output(Rd2ex(rd))
+
+    tc <- textConnection("ex", "w")
+    Rd2ex(rd, commentDonttest = TRUE, out = tc)
+    close(tc)
+
     if(!length(ex))
         return(FALSE)
-    removeDontTest <- function(lines)
-    {
-        idxs <- c()
-        insideDontTest <- FALSE
-        
-        for (i in 1:length(lines))
-        {
-            line = lines[i]
-            if (line == "## No test: "  || insideDontTest || line == "## End(No test)" )
-            {
-                idxs <- append(idxs, i)
-                insideDontTest <- TRUE
-                if (line == "## End(No test)" )
-                        insideDontTest <- FALSE
-            }
-        }
-        if (length(idxs))
-            lines[-idxs]
-        else
-            lines
-    }
-    ex <- removeDontTest(ex)
-    ex <- grep("^\\s*$", ex, invert=TRUE, value=TRUE)
-    ex <- grep("^\\s*#", value=TRUE, ex, invert=TRUE)
-    ex <- ex[nchar(ex) > 0]
-    as.logical(length(ex))
+
+    parsed <- try(parse(text = ex), silent = TRUE)
+
+    length(parsed) && !inherits(parsed, "try-error")
 }
 
 checkForValueSection <- function(pkgdir)

--- a/R/checks.R
+++ b/R/checks.R
@@ -835,6 +835,7 @@ doesManPageHaveRunnableExample <- function(rd)
 
     parsed <- try(parse(text = ex), silent = TRUE)
 
+    # if code contains only comments the length with be 0
     length(parsed) && !inherits(parsed, "try-error")
 }
 

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -587,3 +587,18 @@ test_checkRVersionDependency <- function()
 
     unlink(desc)
 }
+
+test_doesManPageHaveRunnableExample <- function()
+{
+    good <- tools::parse_Rd(
+        system.file("testpackages", "man", "has-devel.Rd",
+            package = "BiocCheck"))
+
+    bad <- tools::parse_Rd(
+        system.file("testpackages", "man", "baddep.Rd",
+            package = "BiocCheck"))
+
+    checkEquals(doesManPageHaveRunnableExample(good), TRUE)
+
+    checkEquals(doesManPageHaveRunnableExample(bad), FALSE)
+}

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -590,13 +590,11 @@ test_checkRVersionDependency <- function()
 
 test_doesManPageHaveRunnableExample <- function()
 {
-    good <- tools::parse_Rd(
-        system.file("testpackages", "man", "has-devel.Rd",
-            package = "BiocCheck"))
+    good <- tools::parse_Rd(system.file("testpackages", "testpkg0", "man",
+            "has-devel.Rd", package = "BiocCheck"))
 
-    bad <- tools::parse_Rd(
-        system.file("testpackages", "man", "baddep.Rd",
-            package = "BiocCheck"))
+    bad <- tools::parse_Rd(system.file("testpackages", "testpkg0", "man",
+            "baddep.Rd", package = "BiocCheck"))
 
     checkEquals(doesManPageHaveRunnableExample(good), TRUE)
 

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -596,7 +596,7 @@ test_doesManPageHaveRunnableExample <- function()
     bad <- tools::parse_Rd(system.file("testpackages", "testpkg0", "man",
             "baddep.Rd", package = "BiocCheck"))
 
-    checkEquals(doesManPageHaveRunnableExample(good), TRUE)
+    checkEquals(BiocCheck:::doesManPageHaveRunnableExample(good), TRUE)
 
-    checkEquals(doesManPageHaveRunnableExample(bad), FALSE)
+    checkEquals(BiocCheck:::doesManPageHaveRunnableExample(bad), FALSE)
 }


### PR DESCRIPTION
Simplify this function and make it more sensitive by

1. Use `commentDonttest` argument to Rd2ex to comment out the donttest
blocks rather than parsing them out by hand.
2. Simply try to parse the remaining code, if parsing fails or the
length is 0 then there is no runnable examples.

Also some basic tests were added using Rd files in the example
packages.