### PR TITLE
Only run checkVersionNumber if not a new package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocCheck
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks. 
-Version: 1.5.7
+Version: 1.5.8
 Authors@R: c(person("Bioconductor", "Package Maintainer",
     email="maintainer@bioconductor.org",
     role=c("aut", "cre")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BiocCheck
 Title: Bioconductor-specific package checks
-Description: Executes Bioconductor-specific package checks.
+Description: Executes Bioconductor-specific package checks. 
 Version: 1.5.5
 Authors@R: c(person("Bioconductor", "Package Maintainer",
     email="maintainer@bioconductor.org",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocCheck
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks. 
-Version: 1.5.5
+Version: 1.5.6
 Authors@R: c(person("Bioconductor", "Package Maintainer",
     email="maintainer@bioconductor.org",
     role=c("aut", "cre")))

--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -102,9 +102,10 @@ BiocCheck <- function(package, ...)
     {
         handleMessage("Checking new package version number...")
         checkNewPackageVersionNumber(package_dir)
+    } else {
+        handleMessage("Checking version number validity...")
+        checkVersionNumber(package_dir)
     }
-    handleMessage("Checking version number validity...")
-    checkVersionNumber(package_dir, !is.null(dots[["new-package"]]))
 
     handleMessage("Checking R Version dependency...")
     checkRVersionDependency(package_dir)

--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -51,7 +51,7 @@ BiocCheck <- function(package, ...)
 
     d <- list(...)
     if (length(d))
-        dots <- list(...)
+        dots <- d[[1]]
     else
         dots <- list()
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -627,7 +627,8 @@ getBadDeps <- function(pkgdir)
     args <- sprintf("-q --vanilla --slave -f %s --args %s",
         system.file("script", "checkBadDeps.R", package="BiocCheck"),
         dQuote(pkgdir))
-    system2(cmd, args, stdout=TRUE, stderr=FALSE)
+    system2(cmd, args, stdout=TRUE, stderr=FALSE,
+        env="R_DEFAULT_PACKAGES=NULL")
 }
 
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -141,7 +141,7 @@ checkNewPackageVersionNumber <- function(pkgdir)
 
 }
 
-checkVersionNumber <- function(pkgdir, new_package=FALSE)
+checkVersionNumber <- function(pkgdir)
 {
     dcf <- read.dcf(file.path(pkgdir, "DESCRIPTION"))
     version <- dcf[, "Version"]

--- a/inst/script/checkBadDeps.R
+++ b/inst/script/checkBadDeps.R
@@ -14,7 +14,6 @@ suppressMessages({
             libdir <- sub("/$|\\$", "", libdir)
         # }
         .libPaths(c(libdir, .libPaths()))
-        library(codetools)
-        cat(capture.output(checkUsageEnv(getNamespace(pkgname))), sep="\n")
+        cat(utils::capture.output(codetools::checkUsageEnv(base::getNamespace(pkgname))), sep="\n")
     })
 })


### PR DESCRIPTION
Puts checkVersionNumber call in an else block and removes the unused new_package parameter.
