### PR TITLE
add default package arg in BiocCheck(), closes #23

### DIFF
--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -41,7 +41,7 @@ usage <- function()
     BiocCheck(file, opt)
 }
 
-BiocCheck <- function(package, ...)
+BiocCheck <- function(package=".", ...)
 {
     .zeroCounters()
     package <- normalizePath(package)


### PR DESCRIPTION
Hi Lori, @lshep 
I've tested this locally (including running via `R CMD BiocCheck <pkg_name>`) and it works without a problem. 
You may also want to refer to the internals of `devtools::install()` for robustness/error messages.

Thanks,
Marcel