### PR TITLE
only test VignetteEngine on first occurrence

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -370,8 +370,7 @@ findLogicalRdir <- function(pkgname, symbol){
 makeTempRFile <- function(infile){
     ext <- tolower(tools::file_ext(infile))
     outfile <- file.path(tempdir(), paste0(basename(infile), ".R"))
-    if(ext == 'rnw' & length(grepPkgDir(
-                infile, "-rn 'VignetteEngine{.*knitr.*}'")) > 0){
+    if(ext == 'rnw' & isTRUE(vigHelper(infile, "knitr")[1])){
         ext <- 'rmd'
     }
     switch(ext,


### PR DESCRIPTION
this is a fix for #31 to overcome the problem if the regex is found within the vignette multiple times with different engines. Eg the vignette in BiocStyle