### PR TITLE
Add a GitHub pull request template

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 inst/testpackages/testpkg1/src/testpkg1.so
+^\.github$

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+---
+name: Pull request
+about: Submit a pull request that resolves an open BiocCheck issue
+title: "[PR] Your pull request"
+labels: ''
+assignees: ''
+---
+
+If you are submitting a pull request to `BiocCheck` please follow the instructions outlined in [this presentation](https://docs.google.com/presentation/d/1DkN2WVPOMVGqUtlSSrWbx6IMjtGP_cEHoE3nfOEnD68/edit#slide=id.p). This presentation includes steps for forking, creating a branch for you to work on, and useful related information.
+
+Prior to sending the pull request, please verify that `R CMD build` and `R CMD check` run without warnings or errors on the latest Bioconductor-devel (currently in May 2020 that would be Bioconductor 3.12) and complete the following steps:
+
+* [ ] Update the NEWS file (required)
+* [ ] Update the Vignette file (required)
+* [ ] Add unit tests (optional)
+* [ ] Add a flag to turn off higher level checks (optional)
+
+The easiest way to obtain a working environment with Bioconductor-devel in your computer is to use the Bioconductor devel docker image as described in detail [in the Bioconductor website](https://www.bioconductor.org/help/docker/).
+
+For more questions, please get in touch with the Bioconductor core team through the [Bioconductor Slack workspace](https://bioc-community.herokuapp.com/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,8 @@ If you are submitting a pull request to `BiocCheck` please follow the instructio
 Prior to sending the pull request, please verify that `R CMD build` and `R CMD check` run without warnings or errors on the latest Bioconductor-devel (currently in May 2020 that would be Bioconductor 3.12) and complete the following steps:
 
 * [ ] Update the NEWS file (required)
-* [ ] Update the Vignette file (required)
+* [ ] Update the vignette file (required)
 * [ ] Add unit tests (optional)
-* [ ] Add a flag to turn off higher level checks (optional)
 
 The easiest way to obtain a working environment with Bioconductor-devel in your computer is to use the Bioconductor devel docker image as described in detail [in the Bioconductor website](https://www.bioconductor.org/help/docker/).
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+CHANGES IN VERSION 1.25
+-----------------------
+
+USER SIGNIFICANT CHANGES
+
+    o (Resolve https://github.com/Bioconductor/BiocCheck/issues/86): Add a
+    GitHub Pull Request template file.
+
 CHANGES IN VERSION 1.23
 -----------------------
 

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -666,3 +666,8 @@ The current list of files checked is as follows:
 
 These files may be included in your personal directories but should be added to
 a `.gitignore` file so they are not git tracked.
+
+# Expanding `BiocCheck`
+
+Contributions to `BiocCheck` are welcome and encouraged through pull requests.
+Please adhere to the Pull Request template when submitting your contributions.


### PR DESCRIPTION
This pull request resolves https://github.com/Bioconductor/BiocCheck/issues/86.


As part of the commit, a new file `.github/pull_request_template.md` was created that contains a template file based on the [GitHub instructions](https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository) and the top lines at [the `biocthis` issue template](https://github.com/lcolladotor/biocthis/blob/master/.github/ISSUE_TEMPLATE/issue_template.md).

Ideally, this file should be properly recognized by GitHub.

The contents of the md file rely heavily on the presentation by Lori Shepard for the BiocCheck-a-thon from May 18th 2020. The contents on the presentation are available at
[https://docs.google.com/presentation/d/1DkN2WVPOMVGqUtlSSrWbx6IMjtGP_cEHoE3nfOEnD68/edit#slide=id.p](here).

This PR also adds the `.github` directory to the `.Rbuildignore`. This can clash with other PRs if they also added this line to the `.Rbuildignore` file.

Best,
Leo