### PR TITLE
v1.25.1 -- Resolve https://github.com/Bioconductor/BiocCheck/issues/57

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.25.0
+Version: 1.25.1
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.25.1
+Version: 1.25.0
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,8 @@ CHANGES IN VERSION 1.25
 
 USER SIGNIFICANT CHANGES
 
-    o (1.25.1) Suggest styler over formatR for automatic code re-formatting.
+    o Resolve <https://github.com/Bioconductor/BiocCheck/issues/57>: Suggest
+    styler over formatR for automatic code re-formatting.
 
 CHANGES IN VERSION 1.23
 -----------------------

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+CHANGES IN VERSION 1.25
+-----------------------
+
+USER SIGNIFICANT CHANGES
+
+    o (1.25.1) Suggest styler over formatR for automatic code re-formatting.
+
 CHANGES IN VERSION 1.23
 -----------------------
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -1431,7 +1431,11 @@ checkFormatting <- function(pkgdir, nlines=6)
         handleMessage(
             "See http://bioconductor.org/developers/how-to/coding-style/")
         handleMessage(
-            "See FormatR package: https://cran.r-project.org/web/packages/formatR/index.html")
+            "See styler package: https://styler.r-lib.org/ ",
+            "as described in the BiocCheck vignette.")
+        handleMessage(
+            "See also biocthis: ",
+            "https://lcolladotor.github.io/biocthis/reference/bioc_style.html")
     }
 }
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -1431,11 +1431,8 @@ checkFormatting <- function(pkgdir, nlines=6)
         handleMessage(
             "See http://bioconductor.org/developers/how-to/coding-style/")
         handleMessage(
-            "See styler package: https://styler.r-lib.org/ ",
+            "See styler package: https://cran.r-project.org/package=styler ",
             "as described in the BiocCheck vignette.")
-        handleMessage(
-            "See also biocthis: ",
-            "https://lcolladotor.github.io/biocthis/reference/bioc_style.html")
     }
 }
 

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -550,10 +550,48 @@ The output of this check includes the first 6 offending lines of code;
 see more with `BiocCheck:::checkFormatting("path/to/YourPackage",
 nlines=Inf)`.
 
-There is a helpful package [formatR][formatR] that can be used for formatting of
-R code to particular coding standards.
+There are several helpful packages that can be used for formatting of
+R code to particular coding standards such as  [formatR][formatR] and
+[styler][styler] as well as the "Reformat code" button in
+[RStudio Desktop][RStudio]. Each solution has its advantages, though 
+[styler][styler] works with `roxygen2` examples and is actively
+maintained. You can re-format your code using [styler][styler] as shown
+below:
+
+```{r reformat_code, eval = FALSE}
+## Install styler if necessary
+if (!requireNamespace("styler", quietly = TRUE)) {
+    install.packages("styler")
+}
+## Automatically re-format the R code in your package
+styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
+
+## If using biocthis:
+styler::style_pkg(transformers = biocthis::bioc_style())
+
+## For your Rmd vignette files:
+styler::style_dir(
+    "vignettes",
+    transformers = biocthis::bioc_style(),
+    filetype = "Rmd"
+)
+```
+
+You can also use [`biocthis::bioc_style()`][biocstyle] which adapts the
+`tidverse_style()` to make it more Bioconductor-friendly. If you are
+working with [RStudio Desktop][RStudio] use also the "Reformat code"
+button which will help you break long lines of code. Alternatively,
+use [formatR][formatR], though beware that it can break valid code
+involving both type of quotation marks (`"` and `'`) and does not
+support re-formatting `roxygen2` examples. In general,
+it is best to version control your code before applying any
+automatic re-formatting solutions and implement unit tests to
+verify that your code runs as intended after you re-format your code.
 
 [formatR]: https://cran.r-project.org/web/packages/formatR/index.html
+[styler]: https://styler.r-lib.org/
+[RStudio]: https://rstudio.com/products/rstudio/download/
+[biocstyle]: https://lcolladotor.github.io/biocthis/reference/bioc_style.html
 
 ## Duplication checks
 

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -565,33 +565,21 @@ if (!requireNamespace("styler", quietly = TRUE)) {
 }
 ## Automatically re-format the R code in your package
 styler::style_pkg(transformers = styler::tidyverse_style(indent_by = 4))
-
-## If using biocthis:
-styler::style_pkg(transformers = biocthis::bioc_style())
-
-## For your Rmd vignette files:
-styler::style_dir(
-    "vignettes",
-    transformers = biocthis::bioc_style(),
-    filetype = "Rmd"
-)
 ```
 
-You can also use [`biocthis::bioc_style()`][biocstyle] which adapts the
-`tidverse_style()` to make it more Bioconductor-friendly. If you are
+If you are
 working with [RStudio Desktop][RStudio] use also the "Reformat code"
 button which will help you break long lines of code. Alternatively,
-use [formatR][formatR], though beware that it can break valid code
-involving both type of quotation marks (`"` and `'`) and does not
+use [formatR][formatR], though beware that it can break valid R code
+involving both types of quotation marks (`"` and `'`) and does not
 support re-formatting `roxygen2` examples. In general,
 it is best to version control your code before applying any
 automatic re-formatting solutions and implement unit tests to
 verify that your code runs as intended after you re-format your code.
 
-[formatR]: https://cran.r-project.org/web/packages/formatR/index.html
-[styler]: https://styler.r-lib.org/
+[formatR]: https://cran.r-project.org/package=formatR
+[styler]: https://cran.r-project.org/package=styler
 [RStudio]: https://rstudio.com/products/rstudio/download/
-[biocstyle]: https://lcolladotor.github.io/biocthis/reference/bioc_style.html
 
 ## Duplication checks
 


### PR DESCRIPTION
Hi,

This pull request resolves https://github.com/Bioconductor/BiocCheck/issues/57 by updating the `handleMessage()` calls after the formatting check fails. Instead of mentioning `formatR`, these messages now refer to:

* `styler`,
* `biocthis`,
* the `BiocCheck` vignette.

Furthermore, the `BiocCheck` vignette section on formatting still mentions `formatR`, but it now also mentions in more detail:

* `styler`: how to install and run it
* `biocthis`: as a companion to `styler` with code how to run it (but not install it since it's optional and the install instructions will hopefully change soon once this package is submitted/reviewed).
* a quick overview of the differences between `formatR` and `styler`, though this is mostly done by highlighting current limitations of `formatR`.
* how RStudio Desktop's `Reformat code` button (under the magic wand) can help break long lines which is something that `styler` cannot do as discussed in more detail at
https://github.com/r-lib/styler/issues/247. `formatR` can do this, but personally, the fact that it broke valid R code in some of my packages made me trust its output less.

The `NEWS` and `DESCRIPTION` files have been updated accordingly.

Best,
Leo