### PR TITLE
BiocCheck-a-thon, Issue65 - better description (not too concise)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.25.0
+Version: 1.25.1
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(
@@ -8,7 +8,8 @@ Authors@R: c(
 	role=c("aut", "cre")),
     person("Lori", "Shepherd", role="ctb"),
     person("Daniel", "von Twisk", role="ctb"),
-    person("Kevin", "Rue", role="ctb"))
+    person("Kevin", "Rue", role="ctb"),
+    person("Federico", "Marini", role="ctb"))
 Depends: R (>= 3.5.0)
 License: Artistic-2.0
 LazyData: true

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+CHANGES IN VERSION 1.25
+-----------------------
+
+NEW FEATURES
+
+    o (1.25.1) Check for warning/notes on too-brief a Description: field,
+    BiocCheck-a-thon issue #65
+
 CHANGES IN VERSION 1.23
 -----------------------
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -345,21 +345,23 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
     })
     
     handleCheck("Checking for proper Description: field...")
-    desc_field <- dcf[, "Description"]
-    desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
-    
-    if (nchar(desc_field) < 50 | desc_words < 20) # values chosen sensibly in a data-driven manner
-        handleWarning("Description field in the DESCRIPTION file is too concise")
-    
-    desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
-    if(desc_sentences < 3) {
-        msg <-
-            "The Description field in the DESCRIPTION is made up by less 
-            than 3 sentences. Please consider expanding this field, and 
-            structure it as a full paragraph"
-        handleNote(paste(strwrap(msg), collapse="\n"))
+    if ("Description" %in% colnames(dcf)) {
+        desc_field <- dcf[, "Description"]
+        desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
+        
+        if (nchar(desc_field) < 50 | desc_words < 20) # values chosen sensibly in a data-driven manner
+            handleWarning("Description field in the DESCRIPTION file is too concise")
+        
+        desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
+        if(desc_sentences < 3) {
+            msg <-
+                "The Description field in the DESCRIPTION is made up by less 
+                than 3 sentences. Please consider expanding this field, and 
+                structure it as a full paragraph"
+            handleNote(paste(strwrap(msg), collapse="\n"))
+        }
     }
-
+    
     handleCheck("Checking for whitespace in DESCRIPTION field names...")
     if (any(grepl("\\s", colnames(dcf))))
     {

--- a/R/checks.R
+++ b/R/checks.R
@@ -1585,5 +1585,13 @@ checkDescription <- function(package_dir){
     
     if (nchar(desc_field) < 50 | desc_words < 6) # values chosen sensibly in a data-driven manner
         handleError("Description field in the DESCRIPTION file is too concise")
-
+    
+    desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
+    if(desc_sentences < 3) {
+        msg <-
+            "The Description field in the DESCRIPTION is made up by less 
+            than 3 sentences. Please consider expanding this field, and 
+            structure it as a full paragraph"
+        handleNote(paste(strwrap(msg), collapse="\n"))
+    }
 }

--- a/R/checks.R
+++ b/R/checks.R
@@ -343,6 +343,22 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
         handleMessage(conditionMessage(err))
         return()
     })
+    
+    handleCheck("Checking for proper Description: field...")
+    desc_field <- dcf[, "Description"]
+    desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
+    
+    if (nchar(desc_field) < 50 | desc_words < 6) # values chosen sensibly in a data-driven manner
+        handleError("Description field in the DESCRIPTION file is too concise")
+    
+    desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
+    if(desc_sentences < 3) {
+        msg <-
+            "The Description field in the DESCRIPTION is made up by less 
+            than 3 sentences. Please consider expanding this field, and 
+            structure it as a full paragraph"
+        handleNote(paste(strwrap(msg), collapse="\n"))
+    }
 
     handleCheck("Checking for whitespace in DESCRIPTION field names...")
     if (any(grepl("\\s", colnames(dcf))))
@@ -1578,20 +1594,4 @@ checkDescription <- function(package_dir){
     handleCheck("Checking for valid maintainer...")
     if (("Authors@R" %in% colnames(dcf)) & any((c("Author","Maintainer") %in% colnames(dcf))))
         handleWarning("Use Authors@R (preferred) or Author/Maintainer fields not both.")
-    
-    handleCheck("Checking for proper Description: field...")
-    desc_field <- dcf[, "Description"]
-    desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
-    
-    if (nchar(desc_field) < 50 | desc_words < 6) # values chosen sensibly in a data-driven manner
-        handleError("Description field in the DESCRIPTION file is too concise")
-    
-    desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
-    if(desc_sentences < 3) {
-        msg <-
-            "The Description field in the DESCRIPTION is made up by less 
-            than 3 sentences. Please consider expanding this field, and 
-            structure it as a full paragraph"
-        handleNote(paste(strwrap(msg), collapse="\n"))
-    }
 }

--- a/R/checks.R
+++ b/R/checks.R
@@ -348,7 +348,7 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
     desc_field <- dcf[, "Description"]
     desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
     
-    if (nchar(desc_field) < 50 | desc_words < 6) # values chosen sensibly in a data-driven manner
+    if (nchar(desc_field) < 50 | desc_words < 20) # values chosen sensibly in a data-driven manner
         handleError("Description field in the DESCRIPTION file is too concise")
     
     desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])

--- a/R/checks.R
+++ b/R/checks.R
@@ -349,7 +349,7 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
     desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
     
     if (nchar(desc_field) < 50 | desc_words < 20) # values chosen sensibly in a data-driven manner
-        handleError("Description field in the DESCRIPTION file is too concise")
+        handleWarning("Description field in the DESCRIPTION file is too concise")
     
     desc_sentences <- length(gregexpr("[[:alnum:] ][.!?]", desc_field)[[1]])
     if(desc_sentences < 3) {

--- a/R/checks.R
+++ b/R/checks.R
@@ -1578,5 +1578,12 @@ checkDescription <- function(package_dir){
     handleCheck("Checking for valid maintainer...")
     if (("Authors@R" %in% colnames(dcf)) & any((c("Author","Maintainer") %in% colnames(dcf))))
         handleWarning("Use Authors@R (preferred) or Author/Maintainer fields not both.")
+    
+    handleCheck("Checking for proper Description: field...")
+    desc_field <- dcf[, "Description"]
+    desc_words <- lengths(strsplit(desc_field, split = "[[:space:]]+"))
+    
+    if (nchar(desc_field) < 50 | desc_words < 6) # values chosen sensibly in a data-driven manner
+        handleError("Description field in the DESCRIPTION file is too concise")
 
 }

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -252,6 +252,11 @@ Can be disabled with `--no-check-bbs`
   file (`ERROR`).
 * **Checking if DESCRIPTION is well formatted...**
    Checks if the DESCRIPTION can be parsed with read.dcf
+* **Checking for proper Description: field...**
+  Checks that the Description field in the DESCRIPTION file has a minimum
+  * number of characters (`ERROR` if less than 50)
+  * number of words (`ERROR` if less than 20)
+  * number of sentences (`NOTE` if less than 3)
 * **Checking for whitespace in DESCRIPTION field names...**
   Checks to make sure there is no whitespace in DESCRIPTION file field
   names (`ERROR`).

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -254,8 +254,8 @@ Can be disabled with `--no-check-bbs`
    Checks if the DESCRIPTION can be parsed with read.dcf
 * **Checking for proper Description: field...**
   Checks that the Description field in the DESCRIPTION file has a minimum
-  * number of characters (`ERROR` if less than 50)
-  * number of words (`ERROR` if less than 20)
+  * number of characters (`WARNING` if less than 50)
+  * number of words (`WARNING` if less than 20)
   * number of sentences (`NOTE` if less than 3)
 * **Checking for whitespace in DESCRIPTION field names...**
   Checks to make sure there is no whitespace in DESCRIPTION file field


### PR DESCRIPTION
I implemented a couple of checks on the content of the Description field, according to the discussion going on in https://github.com/Bioconductor/BiocCheck/issues/65

De facto:
- warning if too few chars or too few words
- note if less than 3 sentences

Right now there are changes in
- R source code
- vignette, documenting the rationale

Unit tests in RUnit have not yet been added. 
I thought that we could avoid duplication of work if we have more people converge on something that has been already implemented.

