### PR TITLE
Remove NOTE for \dontrun{} use in the manual page for an internal function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.25.0
+Version: 1.25.1
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+CHANGES IN VERSION 1.25
+-----------------------
+
+BUG FIXES
+
+    o Usage of donttest and dontrun in manual pages tagged with the keyword 
+    'internal' will no longer trigger a NOTE (#59)
+
 CHANGES IN VERSION 1.23
 -----------------------
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -1242,7 +1242,16 @@ checkUsageOfDont <- function(pkgdir)
             dontrunVec <- vapply(exampleCode, grepl, logical(1),
                                   pattern="\\\\dontrun", perl=TRUE,
                                   USE.NAMES=FALSE)
-            if (any(donttestVec | dontrunVec))
+            ## check for the 'internal' keyword - this will be a false positive
+            keyword <- unlist(lapply(rd,
+                function(x) attr(x, "Rd_tag") == "\\keyword"))
+            if(any(keyword)) {
+                internalVec <- vapply(as.character(rd[keyword]), grepl, logical(1),
+                                     pattern="internal", USE.NAMES=FALSE)
+            } else {
+                internalVec <- FALSE
+            }
+            if (any(donttestVec | dontrunVec) & !any(internalVec))
                 hasBad[dx] = TRUE
         }
     }

--- a/inst/testpackages/testpkg1/man/internal.Rd
+++ b/inst/testpackages/testpkg1/man/internal.Rd
@@ -1,0 +1,30 @@
+\name{internal_function}
+\alias{internal_function}
+\title{
+internal_function
+}
+\description{
+desc
+}
+\usage{
+internal_function()
+}
+%- maybe also 'usage' for other objects documented here.
+\details{
+%%  ~~ If necessary, more details than the description above ~~
+}
+\value{
+%%  ~Describe the value returned
+%%  If it is a LIST, use
+%%  \item{comp1 }{Description of 'comp1'}
+%%  \item{comp2 }{Description of 'comp2'}
+%% ...
+}
+\examples{
+  \dontrun{
+    x <- 1:10
+  }
+}
+% Add one or more standard keywords, see file 'KEYWORDS' in the
+% R documentation directory.
+\keyword{ internal }

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -805,3 +805,24 @@ test_packageAlreadyExists <- function()
     BiocCheck:::checkIsPackageAlreadyInRepo("GenomicRanges", "BioCworkflows")
     checkEquals(.error$getNum(),5)
 }
+
+test_checkUsageOfDont <- function()
+{
+    ## testpkg0 should trigger this note for 2 out of 3 man pages
+    pkgdir <- system.file("testpackages", "testpkg0", package="BiocCheck")
+    BiocCheck:::installAndLoad(pkgdir)
+    notemsg <- capture.output(BiocCheck:::checkUsageOfDont(pkgdir), 
+                              type = "message")
+    checkEquals(1, .note$getNum())
+    # here we verify the correct number of pages were detected
+    checkTrue( any(grepl("67%", notemsg)) )
+    .zeroCounters()
+    
+    ## testpkg1 contains a man page with keyword 'internal' 
+    ## this shouldn't trigger the note
+    pkgdir <- system.file("testpackages", "testpkg1", package="BiocCheck")
+    BiocCheck:::installAndLoad(pkgdir)
+    BiocCheck:::checkUsageOfDont(pkgdir)
+    checkEquals(0, .note$getNum())
+    .zeroCounters()
+}


### PR DESCRIPTION
- Updated checkUsageOfDont() to look for keyword 'internal' and suppress NOTE if found
- Added unit tests to confirm NOTE appears if required, and is suppressed if keyword found.

This address #59, maybe @LiNk-NY would like to review?