### PR TITLE
Usage of 'sapply()' and '1:length()' become a warning instead of a NOTE.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+CHANGES IN VERSION 1.25
+-----------------------
+
+NOTE changes to WARNING
+
+    o 'sapply' and '1:N' NOTE tags become WARNINGS.
+
 CHANGES IN VERSION 1.23
 -----------------------
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -883,19 +883,19 @@ checkCodingPractice <- function(pkgdir, parsedCode, package_name)
 {
     Rdir <- file.path(pkgdir, "R")
 
-    # sapply
+    # sapply warning
     msg_sapply <- checkSapply(Rdir)
     if (length(msg_sapply) > 0) {
-        handleNote(" Avoid sapply(); use vapply()")
+        handleWarning(" Avoid sapply(); use vapply()")
         handleMessage("Found in files:", indent=6)
         for (msg in msg_sapply)
             handleMessage(msg, indent=8)
     }
 
-    # 1:...
+    # 1:... warning
     msg_seq <- check1toN(Rdir)
     if (length(msg_seq) > 0) {
-        handleNote(" Avoid 1:...; use seq_len() or seq_along()")
+        handleWarning(" Avoid 1:...; use seq_len() or seq_along()")
         handleMessage("Found in files:", indent=6)
         for (msg in msg_seq)
             handleMessage(msg, indent=8)

--- a/vignettes/BiocCheck.Rmd
+++ b/vignettes/BiocCheck.Rmd
@@ -377,11 +377,11 @@ directory.
 
 * We recommend that `vapply()` be used instead of `sapply()`. Problems
   arise when the `X` argument to `sapply()` has length 0; the return
-  type is then a `list()` rather than a vector or array. (`NOTE`)
+  type is then a `list()` rather than a vector or array. (`WARNING`)
 
 * We recommend that `seq_len()` or `seq_along()` be used instead of
   `1:...`. This is because the case `1:0` creates the sequence `c(1, 0)`
-  which may be an unexpected or unwanted result (`NOTE`).
+  which may be an unexpected or unwanted result (`WARNING`).
 
 * **Checking for T...** **Checking for F...**
   It is bad practice to use `T` and `F` for `TRUE` and `FALSE`.  This


### PR DESCRIPTION
- Change the Rmd document to show WARNING instead of NOTE.
- Did not bump version in the document.
- Add NEWS file change to log issue.
- This PR addresses #63 