### PR TITLE
update check to include only alpha chars

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -1047,7 +1047,7 @@ checkSingleColon <- function(Rdir, avail_pkgs = character(0L)) {
         tokens <- getParseData(parse(rfile, keep.source = TRUE))
         tokens <- tokens[tokens[,"token"] != "expr", ,drop=FALSE]
         colons <- which(tokens[,"text"] == ":") - 1
-        colons <- colons[tokens[colons, "text"] != c("1", "2")]
+        colons <- colons[grepl("[[:alpha:]]", tokens[colons, "text"])]
         tokens[colons, , drop = FALSE]
     })
     colon_pres <- Filter(nrow, colon_pres)

--- a/inst/testpackages/testpkg0/R/bad_coding.R
+++ b/inst/testpackages/testpkg0/R/bad_coding.R
@@ -12,5 +12,8 @@ bad_fun <- function(){
 invalid_ref <- function() {
 
     bcheck <- BiocCheck:BiocCheck
+    red <- 1
+    xbluex <- 3
+    bcheck <- xbluex:red
 
 }


### PR DESCRIPTION
---
title: "[PR] include only alpha chars"
about: Single colon checks are too greedy limit only to alpha characters
---

**bug fix**

* [x] Update the NEWS file (required)
* [x] Update the vignette file (required)
* [x] Add unit tests (optional)

