### PR TITLE
Fix ORCID ID check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.25.13
+Version: 1.25.14
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ NEW FEATURES
 
 BUG FIXES
 
+    o (1.25.14) The ORCID ID check now accepts IDs with a X at the end.
     o (1.25.9) All packages including infrastructure require a vignette 
     o Usage of donttest and dontrun in manual pages tagged with the keyword 
     'internal' will no longer trigger a NOTE (@grimbough, #59)

--- a/R/checks.R
+++ b/R/checks.R
@@ -349,6 +349,13 @@ checkBiocViews <- function(pkgdir)
     }
 }
 
+.checkORCID <- function(orcid) 
+{
+    re <- "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"
+    grepl(re, orcid)
+}
+
+
 checkBBScompatibility <- function(pkgdir, source_tarball)
 {
     lines <- readLines(file.path(pkgdir, "DESCRIPTION"), warn=FALSE)
@@ -429,7 +436,7 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
         {
             if ("ORCID" %in% names(person$comment)) {
                 orcid <- person$comment[["ORCID"]]
-                validID <- grepl("^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9X]{4}$", orcid)
+                validID <- .checkORCID(orcid)
                 if (!validID)
                     handleNote(
                         "Invalid ORCID ID for ",

--- a/R/checks.R
+++ b/R/checks.R
@@ -429,7 +429,7 @@ checkBBScompatibility <- function(pkgdir, source_tarball)
         {
             if ("ORCID" %in% names(person$comment)) {
                 orcid <- person$comment[["ORCID"]]
-                validID <- grepl("[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}", orcid)
+                validID <- grepl("^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9X]{4}$", orcid)
                 if (!validID)
                     handleNote(
                         "Invalid ORCID ID for ",

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -930,3 +930,17 @@ test_checkUsageOfDont <- function()
     checkEquals(0, .note$getNum())
     .zeroCounters()
 }
+
+test_IsOrcidIdValid = function()
+{
+    orcid <- c(
+        "0000-0001-6197-3471",
+        "0000-0001-6197-347X",
+        "0000-0001-6197-34XX",
+        "0000-0001-6197-3471-0000",
+        "",
+        NA_character_
+    )
+    valid <- c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE)
+    checkIdentical(valid, BiocCheck:::.checkORCID(orcid))
+}


### PR DESCRIPTION
The ORCID ID check didn't accept valid IDs ending with an X. This is now fixed. IDs that are too long are now also rejected.
I updated the NEWS file as requested and bumped the version number of the DESCRIPTION. I didn't update the vignette, because I didn't add any new features.
---
name: Fix ORCID ID check
about: Fix ORCID ID check
title: "[PR] Fix ORCID ID check"
labels: ''
assignees: ''
---

If you are submitting a pull request to `BiocCheck` please follow the instructions outlined in [this presentation](https://docs.google.com/presentation/d/1DkN2WVPOMVGqUtlSSrWbx6IMjtGP_cEHoE3nfOEnD68/edit#slide=id.p). This presentation includes steps for forking, creating a branch for you to work on, and useful related information.

Prior to sending the pull request, please verify that `R CMD build` and `R CMD check` run without warnings or errors on the latest Bioconductor-devel (currently in May 2020 that would be Bioconductor 3.12) and complete the following steps:

* [ ] Update the NEWS file (required)
* [ ] Update the vignette file (required)
* [ ] Add unit tests (optional)

The easiest way to obtain a working environment with Bioconductor-devel in your computer is to use the Bioconductor devel docker image as described in detail [in the Bioconductor website](https://www.bioconductor.org/help/docker/).

For more questions, please get in touch with the Bioconductor core team through the [Bioconductor Slack workspace](https://bioc-community.herokuapp.com/).
