### PR TITLE
Support vignettes with `child = *Rmd` chunks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ BUG FIX
     o (1.27.2) Correct path to R license database file by calling R.home('share').
     o (1.27.3) Correct check for if package already exists in CRAN/Bioc
     o (1.27.3) Correct check for single colon use
+    o (1.27.4) Allow portability of child Rmd documents via parseFile
 
 
 NEW FEATURES

--- a/R/util.R
+++ b/R/util.R
@@ -184,14 +184,9 @@ parseFile <- function(infile, pkgdir)
                 stop("'knitr' package required to check knitr-based vignettes")
             }
             outfile <- file.path(parse_dir, "parseFile.tmp")
-            # copy file to work around https://github.com/yihui/knitr/issues/970
-            # which is actually fixed but not in CRAN yet (3/16/15)
-            tmpin <- file.path(parse_dir, basename(infile))
-            file.copy(infile, tmpin)
             suppressWarnings(suppressMessages(capture.output({
-                knitr::purl(input=tmpin, output=outfile, documentation=0L)
+                knitr::purl(input=infile, output=outfile, documentation=0L)
             })))
-            file.remove(tmpin)
         } else {
             full.infile <- normalizePath(infile)
             oof <- file.path(parse_dir, basename(infile))

--- a/inst/testpackages/testpkg0/vignettes/testpkg0.Rmd
+++ b/inst/testpackages/testpkg0/vignettes/testpkg0.Rmd
@@ -5,3 +5,12 @@
 
 ```{r eval=FALSE}
 ```
+
+```{r eval=FALSE}
+```
+
+```{r eval=FALSE}
+```
+
+```{r, child = "testpkg0_child.Rmd"}
+```

--- a/inst/testpackages/testpkg0/vignettes/testpkg0_child.Rmd
+++ b/inst/testpackages/testpkg0/vignettes/testpkg0_child.Rmd
@@ -1,0 +1,5 @@
+Hi, I'm a child Rmd.
+
+```{r}
+2 + 1
+```

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -185,9 +185,9 @@ test_vignettes0 <- function()
     # 2 WARNINGS - vignette template and evaluate more chunks
     BiocCheck:::checkVignetteDir(system.file("testpackages",
         "testpkg0", package="BiocCheck"), TRUE)
-    checkEquals(4, .warning$getNum())
+    checkEquals(5, .warning$getNum())
     checkEquals("Evaluate more vignette chunks.",
-        .warning$get()[4])
+        .warning$get()[5])
     checkTrue(grepl(pattern="VignetteIndex",  .warning$get()[3]))
     .zeroCounters()
 
@@ -575,6 +575,12 @@ test_parseFile <- function()
     cat("1 + 1", file=testFile)
     df <- BiocCheck:::parseFile(testFile, "BiocCheck")
     checkTrue(all(dim(df) == c(6,9)))
+    ## test that  testpkg0_child.Rmd is read in using `child =` chunk
+    ## in testpkg0.Rmd
+    pkgdir <- system.file("testpackages", "testpkg0", package="BiocCheck")
+    testFile <- file.path(pkgdir, "vignettes", "testpkg0.Rmd")
+    incl <- BiocCheck:::parseFile(testFile, pkgdir)
+    checkTrue(all(c("2", "+", "1") %in% incl[, "text"]))
 }
 
 test_checkForBrowser <- function()


### PR DESCRIPTION
This PR supports the use of `child = ` in Rmd files by removing
old code that copied files in the vignettes directory (as a workaround).
`knitr::purl` currently supports this functionality so we use that instead. 

* [x] Update the NEWS file (required)
* [ ] Update the vignette file (not needed for bug fix)
* [x] Add unit tests (not optional)
