### PR TITLE
Vjcitn patch 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.29.14001
+Version: 1.29.14002
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.29.14
+Version: 1.29.14001
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/R/checks.R
+++ b/R/checks.R
@@ -561,7 +561,7 @@ checkImportSuggestions <- function(pkgname)
     })
 
     if(length(suggestions) && (!is.null(suggestions)) &&
-        (suggestions != "ERROR"))
+        (suggestions[1] != "ERROR"))
     {
             handleMessage("Namespace import suggestions are:")
             handleVerbatim(suggestions, indent=4, exdent=4, width=100000)

--- a/R/util.R
+++ b/R/util.R
@@ -277,7 +277,7 @@ findSymbolInParsedCode <- function(parsedCode, pkgname, symbolName,
 }
 
 getDirFile <- function(fpath) {
-    if (length(fpath) && !is.na(fpath))
+    if (length(fpath) && !all(is.na(fpath)))
         vapply(
             strsplit(normalizePath(fpath), .Platform$file.sep),
             function(pseg) {


### PR DESCRIPTION
If you are submitting a pull request to `BiocCheck` please follow the
[instructions](https://docs.google.com/presentation/d/1DkN2WVPOMVGqUtlSSrWbx6IMjtGP_cEHoE3nfOEnD68/edit#slide=id.p).
The presentation includes steps for forking, creating a working branch, and
useful related information.

For a successful merge, the following steps are required:

* [ ] Update the NEWS file
* [ ] Update the vignette file
* [ ] Add unit tests (optional but highly recommended)
* [ ] Passing `R CMD build` & `R CMD check` on Bioconductor devel

List a reviewer in the Pull Request (either @LiNk-NY, @lshep, @mtmorgan).
Reviewers will make sure to `Comment`, `Approve` or `Request changes`.

We _highly_ recommend the use of the Bioconductor devel docker image described
[on the Bioconductor website](https://www.bioconductor.org/help/docker/).

If you have any questions, please get in touch with the Bioconductor core team
on the [Bioconductor Community Slack](https://bioc-community.herokuapp.com/).

@Link-NY I have now produced the problem on Linux with the current biodb package submission.

```
* Checking .Rbuildignore...
    * ERROR: .Rbuildignore file includes the 'tests' folder.
* Checking vignette directory...
    * NOTE: 'sessionInfo' not found in vignette(s)
      Missing from file(s):
 ----------- FAILURE REPORT -------------- 
 --- failure: length > 1 in coercion to logical ---
 --- srcref --- 
: 
 --- package (from environment) --- 
BiocCheck
 --- call from context --- 
getDirFile(vigfiles[notFoundVig])
 --- call from argument --- 
length(fpath) && !is.na(fpath)
 --- R stacktrace ---
where 1: getDirFile(vigfiles[notFoundVig])
where 2: paste0(...)
where 3: handleMessage(getDirFile(vigfiles[notFoundVig]), indent = 8)
where 4: checkVigSessionInfo(pkgdir)
where 5: checkVignetteDir(package_dir, checkingDir)
...
```

With my patch this does not occur.  It seems to occur when there are multiple vignettes offered.  This
must be pretty uncommon for applications of BiocCheck for this not to surface easily?

This sessionInfo uses my patched BiocCheck
```
> sessionInfo()
R version 4.1.1 Patched (2021-09-30 r81005)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 20.04.2 LTS

Matrix products: default
BLAS:   /home/stvjc/R-4-1-dist/lib/R/lib/libRblas.so
LAPACK: /home/stvjc/R-4-1-dist/lib/R/lib/libRlapack.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] biodb_1.1.11   rmarkdown_2.11

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.7           stringdist_0.9.8     prettyunits_1.1.1   
 [4] assertthat_0.2.1     digest_0.6.28        utf8_1.2.2          
 [7] BiocFileCache_2.1.1  R6_2.5.1             plyr_1.8.6          
[10] stats4_4.1.1         RSQLite_2.2.8        evaluate_0.14       
[13] httr_1.4.2           pillar_1.6.3         biocViews_1.61.1    
[16] rlang_0.4.11         progress_1.2.2       curl_4.3.2          
[19] rstudioapi_0.13      blob_1.2.2           RUnit_0.4.32        
[22] startup_0.15.0       stringr_1.4.0        RCurl_1.98-1.5      
[25] bit_4.0.4            compiler_4.1.1       xfun_0.26           
[28] pkgconfig_2.0.3      askpass_1.1          BiocGenerics_0.39.2 
[31] htmltools_0.5.2      openssl_1.4.5        tidyselect_1.1.1    
[34] tibble_3.1.5         lgr_0.4.3            codetools_0.2-18    
[37] BiocCheck_1.29.14001 XML_3.99-0.8         fansi_0.5.0         
[40] crayon_1.4.1         dplyr_1.0.7          dbplyr_2.1.1        
[43] withr_2.4.2          bitops_1.0-7         rappdirs_0.3.3      
[46] RBGL_1.69.0          jsonlite_1.7.2       lifecycle_1.0.1     
[49] DBI_1.1.1            magrittr_2.0.1       graph_1.71.2        
[52] stringi_1.7.5        cachem_1.0.6         getopt_1.20.3       
[55] optparse_1.6.6       ellipsis_0.3.2       chk_0.7.0           
[58] filelock_1.0.2       generics_0.1.0       vctrs_0.3.8         
[61] tools_4.1.1          bit64_4.0.5          Biobase_2.53.0      
[64] glue_1.4.2           purrr_0.3.4          hms_1.1.1           
[67] parallel_4.1.1       fastmap_1.1.0        yaml_2.2.1          
[70] BiocManager_1.30.16  memoise_2.0.0        knitr_1.36  
```
