### PR TITLE
Get package name from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.31.5
+Version: 1.31.6
 Title: Bioconductor-specific package checks
 Description: Executes Bioconductor-specific package checks.
 Authors@R: c(

--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -95,7 +95,7 @@ BiocCheck <- function(package=".", ...)
     if (length(package)==0)
         .stop("Supply a package directory or source tarball.")
     package_dir <- .get_package_dir(package)
-    package_name <- .get_package_name(package)
+    package_name <- .get_package_name(package_dir)
 
     handleMessage(
         "This is BiocCheck version ", packageVersion("BiocCheck"), ". ",
@@ -318,9 +318,10 @@ BiocCheck <- function(package=".", ...)
 
 }
 
-.get_package_name <- function(input)
+.get_package_name <- function(package_dir)
 {
-    strsplit(basename(input), "_")[[1]][1]
+    read.dcf(file = file.path(package_dir,"DESCRIPTION"),
+             fields = "Package")[[1]]
 }
 
 .get_package_dir <- function(pkgname)

--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -321,7 +321,7 @@ BiocCheck <- function(package=".", ...)
 .get_package_name <- function(package_dir)
 {
     read.dcf(file = file.path(package_dir,"DESCRIPTION"),
-             fields = "Package")[[1]]
+             fields = "Package")[[1]] 
 }
 
 .get_package_dir <- function(pkgname)

--- a/R/BiocCheckGitClone.R
+++ b/R/BiocCheckGitClone.R
@@ -57,7 +57,7 @@ BiocCheckGitClone <- function(package=".", ...){
     if (length(package)==0)
         .stop("Supply a package directory or source tarball.")
     package_dir <- .get_package_dir(package)
-    package_name <- .get_package_name(package)
+    package_name <- .get_package_name(package_dir)
 
     handleMessage(
         "This is BiocCheckGitClone version ", packageVersion("BiocCheck"), ". ",


### PR DESCRIPTION
Rather than assuming the folder name is identical to the package name (not always the case), get the package name from the DESCRIPTION file (which will always be available and congruent with the actual package name).

For further details on the downstream errors that using folder name as package name can cause, please see #144  

* [x] Update the NEWS file
* ~~[ ] Update the vignette file~~ (*NA*)
* ~~[ ] Add unit tests (optional but highly recommended)~~ (*NA*)
* ~~[ ] Passing `R CMD build` & `R CMD check` on Bioconductor devel~~ (*Checks were not passing prior to PR edits.*)
 
@LiNk-NY @mtmorgan 
