### PR TITLE
Test for `NULL` data.frame in `checkFunctionLengths()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.31.32
+Version: 1.31.33
 Title: Bioconductor-specific package checks
 Description: BiocCheck guides maintainers through Bioconductor best
   practicies. It runs Bioconductor-specific package checks by searching through

--- a/R/checks.R
+++ b/R/checks.R
@@ -1580,7 +1580,7 @@ checkFunctionLengths <- function(parsedCode, pkgname)
     dflist <- Filter(length, dflist)
     df <- do.call(rbind, dflist)
     colnames <- c("filename","functionName","length","startLine","endLine")
-    if (ncol(df) == length(colnames))
+    if (!is.null(df) && ncol(df) == length(colnames))
     {
         colnames(df) <- colnames
         df <- df[with(df, order(-length)),]


### PR DESCRIPTION
Hi @LiNk-NY thanks for the works you're doing on this package.

I sometimes run `BiocCheck` on an "empty" package created by `usethis::create_package()` which has no functions.  In this situation the refactoring of `checkFunctionLenths()` will create a `NULL` rather than a `data.frame` with zero rows as it did before. This occurs on the following line what `dflist` is a list of length zero.

https://github.com/Bioconductor/BiocCheck/blob/3816e7bc9155379292f6038c0c269f5ef902dac1/R/checks.R#L1581

This in turn breaks the tests on the line below for whether to enter the reporting code with the error `Error in if (ncol(df) == length(colnames)) { : argument is of length zero`

https://github.com/Bioconductor/BiocCheck/blob/3816e7bc9155379292f6038c0c269f5ef902dac1/R/checks.R#L1583

This pull request adds a test for `NULL` and will then skip the tests.  I haven't thought about whether this should actually be the only test - can you still get a `df` which is a data.frame but where the number of columns is not 5?
