### PR TITLE
getDirFile is expected to work vectorized

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ CHANGES IN VERSION 1.34
 
 BUG FIXES AND MINOR IMPROVEMENTS
 
+    o Fix "Warning in nzchar(fpath) && !is.na(fpath)" when checking man page
+    documentation (@zeehio, #163)
     o Allow lookback for matching T/F and exclude list elements, e.g., `list$F`
     (@lshep, #161)
     o Fix indentation count by excluding yaml front matter from vignettes

--- a/R/util.R
+++ b/R/util.R
@@ -308,10 +308,11 @@ findSymbolInParsedCode <- function(parsedCode, pkgname, symbolName,
 }
 
 getDirFile <- function(fpath) {
-    if (nzchar(fpath) && !is.na(fpath))
-        fpath <- file.path(basename(dirname(fpath)), basename(fpath))
-
-    fpath
+    ifelse(
+        nzchar(fpath) & !is.na(fpath),
+        file.path(basename(dirname(fpath)), basename(fpath)),
+        fpath
+    )
 }
 
 .getTokenTextCode <- function(parsedf, token, text, lookback = character(0)) {

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -1421,3 +1421,11 @@ test_IsOrcidIdValid = function()
     valid <- c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE)
     checkIdentical(valid, BiocCheck:::.checkORCID(orcid))
 }
+
+
+test_getDirFile <- function()
+{
+    input <- c(NA, "z/a/b.c", "")
+    valid <- c(NA, "a/b.c", "")
+    checkIdentical(valid, BiocCheck:::getDirFile(input))
+}


### PR DESCRIPTION
When checking the man page documentation had issues I found some warnings. This pull request addresses them:

```
* Checking man page documentation...
Warning in nzchar(fpath) && !is.na(fpath) :
  'length(x) = 5 > 1' in coercion to 'logical(1)'
Warning in nzchar(fpath) && !is.na(fpath) :
  'length(x) = 5 > 1' in coercion to 'logical(1)'
```

* [x] Update the NEWS file
* [ ] Update the vignette file (not needed)
* [x] Add unit tests (optional but highly recommended)
* [ ] Passing `R CMD build` & `R CMD check` on Bioconductor devel (no warnings added)

Requesting review by @LiNk-NY

