### PR TITLE
Fix False positive warning in "Import {pkg} in NAMESPACE as well as DESCRIPTION."

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ CHANGES IN VERSION 1.34
 
 BUG FIXES AND MINOR IMPROVEMENTS
 
+    o Fix false positive WARNING "Import {pkg} in NAMESPACE as well as
+    DESCRIPTION." where pkg was not in NAMESPACE but it was used using double
+    colons pkg::function inside an S4 method. (@zeehio, #166)
     o Fix bug where inputs to `getDirFile` were vectors in
     `checkForValueSection` (@zeehio, #163)
     o Allow lookback for matching T/F and exclude list elements, e.g., `list$F`

--- a/R/util.R
+++ b/R/util.R
@@ -668,6 +668,10 @@ getParent <- function(view, biocViewsVocab)
         v <- get(n, envir = env)
         if (typeof(v) == "closure")
             walkCode(body(v), walker)
+        else if (typeof(v) == "environment" && !walker$is_explored(v)) {
+            walker$mark_exploration(v)
+            .checkEnv(v, walker)
+        }
     }
     walker
 }
@@ -675,8 +679,11 @@ getParent <- function(view, biocViewsVocab)
 .colonWalker <- function() {
     ## record all pkg used as pkg::foo or pkg:::bar
     PKGS <- character()
+    EXPLORED_ENVIRS <- character()
     collector <- function(e, w)
         PKGS <<- append(PKGS, as.character(e[[2]]))
+    mark_exploration <- function(env)
+        EXPLORED_ENVIRS <<- append(EXPLORED_ENVIRS, format(env))
     list(handler=function(v, w) {
         switch(v, "::"=collector, ":::"=collector, NULL)
     }, call=function(e, w) {
@@ -685,7 +692,10 @@ getParent <- function(view, biocViewsVocab)
         NULL
     }, done = function() {
         sort(unique(PKGS))
-    })
+    }, is_explored = function(env) {
+       format(env) %in% EXPLORED_ENVIRS
+    }, mark_exploration = mark_exploration
+    )
 }
 
 getFunctionLengths <- function(df)

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -1438,3 +1438,39 @@ test_getDirFile <- function() {
     )
     checkException(getDirFile(vigfiles))
 }
+
+
+test_checkEnv <- function() {
+    # Simple function in empty environment:
+    env <- new.env(parent = emptyenv())
+    env$f <- function() BiocCheck::BiocCheck
+    dcolon <- BiocCheck:::.checkEnv(env, BiocCheck:::.colonWalker())$done()
+    checkIdentical(dcolon, "BiocCheck")
+
+    # Function inside environment inside environment
+    # This happens on pkg ns environments with S4 methods
+    env <- new.env(parent = emptyenv())
+    env$another <- new.env(parent = emptyenv())
+    env$another$f <- function() BiocCheck::BiocCheck
+    dcolon <- BiocCheck:::.checkEnv(env, BiocCheck:::.colonWalker())$done()
+    checkIdentical(dcolon, "BiocCheck")
+
+    # Environments can contain themselves. Check that this does not
+    # lead to an infinite loop
+    env <- new.env(parent = emptyenv())
+    env$another <- env
+    env$another$f <- function() BiocCheck::BiocCheck
+    dcolon <- BiocCheck:::.checkEnv(env, BiocCheck:::.colonWalker())$done()
+    checkIdentical(dcolon, "BiocCheck")
+
+    # Environments can contain other envs that can contain the first env.
+    # Check that this does not lead to an infinite loop
+    env <- new.env(parent = emptyenv())
+    env$another <- new.env(parent = emptyenv())
+    env$another$env2 <- env
+    env$another$env2$f <- function() BiocCheck::BiocCheck
+    dcolon <- BiocCheck:::.checkEnv(env, BiocCheck:::.colonWalker())$done()
+    checkIdentical(dcolon, "BiocCheck")
+}
+
+


### PR DESCRIPTION
Hi,


* [x] Update the NEWS file
* [ ] Update the vignette file
* [x] Add unit tests (optional but highly recommended)
* [x] Passing `R CMD build` & `R CMD check` on Bioconductor devel

Could @LiNk-NY or any other maintainer check and review this, please?


I am getting a false positive WARNING "Import {pkg} in NAMESPACE as well as DESCRIPTION." when pkg is being used inside an S4 method with a `pkg::fun` syntax. 

The warning should appear when a package found in Imports is not used in the NAMESPACE and it is not used as well using a double/triple colon syntax. To find packages used with a double/triple colon syntax, BiocCheck uses the `BiocCheck:::.checkEnv` function. This function loads the namespace of the package under analysis and traverses all its closures, looking for `::` and `:::` calls and keeping the list of packages being used. One current limitation of the `.checkEnv()` function is that if the package namespace contains an environmemt, the environment is not traversed, so functions defined inside those environments are never checked.

This limitation of `.checkEnv()` is a problem because S4 methods are recorded in the package namespace as environments. If an S4 method uses a double colon call, it won't be catched by .checkEnv() leading to a false positive warning.

Here I show how methods are stored inside a package namespace:

``` r
# Load a package with s4 methods:
pkg_ns <- loadNamespace("xcms")
pkg_ns
#> <environment: namespace:xcms>
# It has a lot of stuff inside:
ls(pkg_ns, all.names = TRUE)[110:120]
#>  [1] ".__T__family:stats"               ".__T__family<-:xcms"             
#>  [3] ".__T__featureDefinitions:xcms"    ".__T__featureDefinitions<-:xcms" 
#>  [5] ".__T__featureGroups:MsFeatures"   ".__T__featureGroups<-:MsFeatures"
#>  [7] ".__T__featureValues:xcms"         ".__T__fileIndex:xcms"            
#>  [9] ".__T__fileIndex<-:xcms"           ".__T__fileName:BiocGenerics"     
#> [11] ".__T__filepaths:xcms"
# Here is a method (`featureGroups`) which generic belongs to another package (`MsFeatures`). It's an environment:
pkg_ns$`.__T__featureGroups:MsFeatures`
#> <environment: 0x55fe4500e6f0>
# What does the environment of this method contain?
ls(pkg_ns$`.__T__featureGroups:MsFeatures`, all.names = TRUE)
#> [1] "XCMSnExp"
# It contains the signatures and closures the xcms package provides:
pkg_ns$`.__T__featureGroups:MsFeatures`$XCMSnExp
#> Method Definition:
#> 
#> function (object, ...) 
#> {
#>     .local <- function (object) 
#>     {
#>         if (!hasFeatures(object)) 
#>             stop("No feature definitions present. Please run 'groupChromPeak'", 
#>                 call. = FALSE)
#>         if (any(colnames(featureDefinitions(object)) == "feature_group")) 
#>             as.character(featureDefinitions(object)$feature_group)
#>         else rep(NA_character_, nrow(featureDefinitions(object)))
#>     }
#>     .local(object, ...)
#> }
#> <bytecode: 0x55fe4500f170>
#> <environment: namespace:xcms>
#> 
#> Signatures:
#>         object    
#> target  "XCMSnExp"
#> defined "XCMSnExp"
# That's one closure BiocCheck should be parsing for :: calls for!
```

<sup>Created on 2022-08-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

To address this limitation, I've modified the .checkEnv function to recursively explore the environments found in the namespace.
Since an environment can contain itself, I've added some state information to the walker to prevent infinite loops.

I have added unit tests to ensure my contribution works and doesn't fail in the future. 


