### PR TITLE
Fixed .BAD_INSTALL_CALLS

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -930,7 +930,7 @@ checkVigBiocInst <- function(pkgdir) {
 }
 
 .BAD_INSTALL_CALLS <- c("biocLite", "install.packages", "install_packages",
-    "update.packages", "install")
+    "update.packages", "install$")
 
 checkVigInstalls <- function(pkgdir) {
     msg_return <- findSymbolsInVignettes(


### PR DESCRIPTION
Hi, @LiNk-NY 

This is a small fix to a change you introduced in **v1.33.17**. Now, it makes sure `checkVigInstalls()` only flags `BiocManager::install()`, not any other function containing the string "install" in its name.

I have 2 packages that use external dependencies, so I use helper functions in the vignette named `<tool>_is_installed()` (e.g., https://github.com/almeidasilvaf/syntenet/blob/31c3784557fc7cc5a4b7886a7aa3c9a1aec57881/vignettes/syntenet.Rmd#L207) to evaluate the functions conditionally. I've seen at least 2 other packages that do the same. Thus, your change on v1.33.17 will break some packages.

* [ ] Update the NEWS file (it's really minor, so I don't think it's worth updating)
* [ ] Update the vignette file (nothing to update, I think)
* [ ] Add unit tests (optional but highly recommended)
* [x] Passing `R CMD build` & `R CMD check` on Bioconductor devel

Best,
Fabricio