### PR TITLE
Properly check pkg installation calls in vignettes

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -930,7 +930,7 @@ checkVigBiocInst <- function(pkgdir) {
 }
 
 .BAD_INSTALL_CALLS <- c("biocLite", "install.packages", "install_packages",
-    "update.packages", "install")
+    "update.packages", "install$", "install_")
 
 checkVigInstalls <- function(pkgdir) {
     msg_return <- findSymbolsInVignettes(


### PR DESCRIPTION
Hi, @lshep and @LiNk-NY 

I extended the changes in my previous pull request from earlier today (#169) to include installation functions from {remotes} and {devtools} (`install_github`, `install_gitlab`, `install_bioc`, etc)

Now, `BiocCheck::BiocCheck()` will flag package installation calls in evaluated vignette code (including `install_*` functions from {remotes}/{devtools} and `install()` from {BiocManager} and {devtools}), but it will not misidentify logical functions `<tool>_is_installed()` as problematic, because they do not end in "install".


* [ ] Update the NEWS file (not applicable)
* [ ] Update the vignette file (not applicable)
* [ ] Add unit tests (optional but highly recommended)
* [x] Passing `R CMD build` & `R CMD check` on Bioconductor devel

Best,
Fabricio