### PR TITLE
Fixed missing space

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -1746,7 +1746,7 @@ checkExportsAreDocumented <- function(pkgdir, pkgname, lib.loc)
         )
     else if (length(badManPages))
         handleNote(
-            "Consider adding runnable examples to man pages that document",
+            "Consider adding runnable examples to man pages that document ",
             "exported objects.",
             messages = badManPages
         )


### PR DESCRIPTION
Fixed a missing space that caused the note to be printed as
`* NOTE: Consider adding runnable examples to man pages that documentexported objects.`