### PR TITLE
Fix for failing getBiocCheckDir unit test on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.35.0
+Version: 1.35.1
 Title: Bioconductor-specific package checks
 Description: BiocCheck guides maintainers through Bioconductor best
   practicies. It runs Bioconductor-specific package checks by searching through

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+CHANGES IN VERSION 1.36
+
+BUG FIXES AND MINOR IMPROVEMENTS
+
+    o Fix issue with path seperators on Windows ('//' vs '\') causing the unit 
+    test test_getBiocCheckDir to report erroneous mismatches
+
 CHANGES IN VERSION 1.34
 -----------------------
 

--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,8 @@ CHANGES IN VERSION 1.36
 
 BUG FIXES AND MINOR IMPROVEMENTS
 
-    o Fix issue with path seperators on Windows ('//' vs '\') causing the unit 
-    test test_getBiocCheckDir to report erroneous mismatches
+    o Fix issue with path seperators on Windows ('\\' vs '/') causing the unit 
+    test for getBiocCheckDir to report erroneous mismatches
 
 CHANGES IN VERSION 1.34
 -----------------------

--- a/R/BiocCheck.R
+++ b/R/BiocCheck.R
@@ -429,7 +429,7 @@ BiocCheckRun <-
 }
 
 .getBiocCheckDir <- function(pkgName, checkDir) {
-    checkDir <- normalizePath(checkDir)
+    checkDir <- normalizePath(checkDir, winslash = "/")
     file.path(
         checkDir, paste(pkgName, "BiocCheck", sep = ".")
     )


### PR DESCRIPTION
For a successful merge, the following steps are required:

* [x] Update the NEWS file
* [x] Passing `R CMD build` & `R CMD check` on Bioconductor devel

This patch addresses failing `test_getBiocCheckDir` unit test on Windows, which is a false negative.

By default `normalizePath()` which is now used in `getBiocCheckDir`  will introduce `\\` into Windows paths.  However, this is being tested against a path using `file.path` which separates things with `/`.

On my system I end up with:

`"C:\\Users\\grimb\\AppData\\Local\\R\\win-library\\4.3\\BiocCheck\\testpackages/testpkg0.BiocCheck"`
and
`"C:/Users/grimb/AppData/Local/R/win-library/4.3/BiocCheck/testpackages/testpkg0.BiocCheck"`

This patch just sets `normalizePath()` to use `/`, so the test should report TRUE again.

----

I suspect the other failing unit test is because `citeEntry()` was changed to allow a citation to not include the `textVersion` argument, and omitting this is how the test simulates a broken citation. Probably need to come up with a new way to break the citation file.  See:

https://github.com/wch/r-source/commit/63822e024d9840acd2b8541ade78c657a7533029
