### PR TITLE
Error in reporting number of "long" functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BiocCheck
-Version: 1.35.9
+Version: 1.35.10
 Title: Bioconductor-specific package checks
 Description: BiocCheck guides maintainers through Bioconductor best
   practicies. It runs Bioconductor-specific package checks by searching through

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ BUG FIXES AND MINOR IMPROVEMENTS
     `checkDeprecatedPkgs`
     o Fix issue with path seperators on Windows ('\\' vs '/') causing the unit
     test for `getBiocCheckDir` to report erroneous mismatches (@grimbough, #175)
+    o Fix bug where the wrong number of functions with length greater than 50
+    was reported (@grimbough, #182)
 
 CHANGES IN VERSION 1.34
 -----------------------

--- a/R/checks.R
+++ b/R/checks.R
@@ -1543,9 +1543,9 @@ checkFunctionLengths <- function(parsedCode, pkgname)
                 )
             })
             statusmsg <- paste(
-                "There are", nrow(df), "functions greater than 50 lines."
+                "There are", nrow(h), "functions greater than 50 lines."
             )
-            statusmsg <- .singularize(df, statusmsg)
+            statusmsg <- .singularize(h, statusmsg)
             handleNote(
                 "The recommended function length is 50 lines or less. ",
                 statusmsg,

--- a/inst/testpackages/testpkg0/R/bad_coding.R
+++ b/inst/testpackages/testpkg0/R/bad_coding.R
@@ -71,3 +71,58 @@ check_install <- function(pkg) {
 check_inst_pkg <- function(pkg = "getPass") {
     check_install(pkg = pkg)
 }
+
+## test functions > 50 lines are reported
+really_long_function <- function() {
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  return(TRUE)
+}

--- a/inst/unitTests/test_BiocCheck.R
+++ b/inst/unitTests/test_BiocCheck.R
@@ -1051,6 +1051,17 @@ test_getFunctionLengths2 <- function()
 {
     load(system.file("unitTests", "IRangesParsedCode.rda", package="BiocCheck"))
     BiocCheck:::checkFunctionLengths(IRangesParsedCode, "IRanges")
+    .zeroCounters()
+    
+    ## we should find 1 function that is greater than 50 lines long
+    parsedCode <- BiocCheck:::parseFiles(system.file("testpackages", "testpkg0",
+                                                     package="BiocCheck"))
+    res <- BiocCheck:::checkFunctionLengths(parsedCode, "testpkg0")
+    checkEqualsNumeric(BiocCheck:::.BiocCheck$getNum("note"), 1)
+    checkTrue(grepl(pattern = "There is 1 function greater than 50 lines", 
+                    x = BiocCheck:::.BiocCheck$note$checkFunctionLengths[[1]]),
+              msg = "Checking we report functions > 50 lines long.")
+    .zeroCounters()
 }
 
 test_checkExportsAreDocumented <- function()


### PR DESCRIPTION
For a successful merge, the following steps are required:

* [x] Update the NEWS file
* [ ] Update the vignette file
* [x] Add unit tests (optional but highly recommended)
* [x] Passing `R CMD build` & `R CMD check` on Bioconductor devel

List a reviewer in the Pull Request (either @LiNk-NY, @lshep, @mtmorgan).
Reviewers will make sure to `Comment`, `Approve` or `Request changes`.


Hi @LiNk-NY,

I think this is a tiny bug fix.  At the moment, when I run `BiocCheck()` on a package I'm working on package I get:

```
* Checking function lengths...
    * NOTE: The recommended function length is 50 lines or less. There are 35 functions greater than 50 lines.
```

However, 35 is the total number of functions in the package, not the number greater than 50 lines.  It think the code is just  reporting the length of the wrong `data.frame` in that test, and this patch fixes that.