### PR TITLE
Add commonmark to DESCRIPTION dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     callr,
     cli,
     codetools,
+    commonmark,
     graph,
     httr2,
     knitr,
@@ -37,7 +38,8 @@ Imports:
     rvest,
     stringdist,
     tools,
-    utils
+    utils,
+    xml2
 Suggests: 
     BiocStyle,
     devtools,

--- a/R/checks.R
+++ b/R/checks.R
@@ -513,7 +513,7 @@ checkNEWS <- function(pkgdir)
     }, error=function(e){
         handleWarning(
             "news(package='", basename(pkgdir), "') failed with news file: ",
-            newsPath, ".",
+            newsPath, ":", e$message,
             "\nRefer to https://contributions.bioconductor.org/news.html",
             " to be included in Bioconductor release announcements."
         )


### PR DESCRIPTION
The `commonmark` package is needed for parsing the `NEWS.md` file, see `help('news', package = 'utils')`.

Fixes https://github.com/r-universe-org/help/issues/649
