### PR TITLE
Allow RemoteRef, RemoteUrl, RemoteSha, etc used by R-universe.

### DIFF
--- a/R/checkDESCRIPTION.R
+++ b/R/checkDESCRIPTION.R
@@ -357,7 +357,7 @@ checkValidDESCfields <- function(dcf) {
         c("RoxygenNote", "Video")
     )
 
-    is_config_field <- grepl("^Config/", present_fields)
+    is_config_field <- grepl("^Remote|Config/", present_fields)
     fields_to_check <- present_fields[!is_config_field]
 
     bad_fields <- fields_to_check[!(fields_to_check %in% known_fields)]


### PR DESCRIPTION
Fixes some false positives that users see on r-universe, for example: https://github.com/r-universe/biocstaging/actions/runs/30213122542/job/89823311003#step:5:1