### PR TITLE
Use names= rather than .Names= in structure()

### DIFF
--- a/R/BiocCheck-class.R
+++ b/R/BiocCheck-class.R
@@ -142,7 +142,7 @@ NULL
                 "<Internal> Input to '$add' must be a list" = is.list(mlist)
             )
             ins <- Filter(length, list(mlist, help_text, messages))
-            nist <- structure(list(ins), .Names = names(mlist))
+            nist <- structure(list(ins), names = names(mlist))
             .messages$setMessage(nist, condition = condition)
             .self[[condition]] <- append(.self[[condition]], nist)
             .self$log[[checkName]] <- append(.self$log[[checkName]], nist)

--- a/R/checkRcoding.R
+++ b/R/checkRcoding.R
@@ -414,7 +414,7 @@ checkCatInRCode <-
 {
     rfiles <- .BiocPackage$RSources
     parsedCodes <- lapply(
-        structure(rfiles, .Names = rfiles), parseFile,
+        structure(rfiles, names = rfiles), parseFile,
         .BiocPackage = .BiocPackage
     )
     parsedCodes <- lapply(parsedCodes, .filtersetMethodRanges)
@@ -432,7 +432,7 @@ checkEqInAssignment <-
 {
     rfiles <- .BiocPackage$RSources
     parsedCodes <- lapply(
-        structure(rfiles, .Names = rfiles), parseFile,
+        structure(rfiles, names = rfiles), parseFile,
         .BiocPackage = .BiocPackage
     )
     msg_res <- findSymbolsInParsedCode(
@@ -541,7 +541,7 @@ checkExternalData <- function(.BiocPackage) {
 checkOnAttachLoadCalls <- function(.BiocPackage) {
     rfiles <- .BiocPackage$RSources
     parsedCodes <- lapply(
-        structure(rfiles, .Names = rfiles), parseFile,
+        structure(rfiles, names = rfiles), parseFile,
         .BiocPackage = .BiocPackage
     )
     parsedCodes <- lapply(parsedCodes, function(tokens) {

--- a/R/checkVignettes.R
+++ b/R/checkVignettes.R
@@ -429,7 +429,7 @@ checkVigEvalAllFalse <- function(.BiocPackage) {
     vigfiles <- .BiocPackage$VigSources
     shortnames <- .getDirFiles(vigfiles)
     viglist <- structure(
-        vector("logical", length(vigfiles)), .Names = shortnames
+        vector("logical", length(vigfiles)), names = shortnames
     )
     for (i in seq_along(vigfiles)) {
         shortName <- shortnames[i]
@@ -462,7 +462,7 @@ checkVigEvalAllFalse <- function(.BiocPackage) {
 checkDupChunkLabels <- function(vigfiles) {
     viglist <- structure(
         vector("logical", length(vigfiles)),
-        .Names = vigfiles
+        names = vigfiles
     )
     for (vfile in vigfiles) {
         tempR <- tempfile(fileext=".R")
@@ -519,7 +519,7 @@ checkDupChunkLabels <- function(vigfiles) {
 checkChunkLabels <- function(vigfiles) {
     viglist <- structure(
         vector("logical", length(vigfiles)),
-        .Names = vigfiles
+        names = vigfiles
     )
     for (vfile in vigfiles) {
         viglines <- readLines(vfile, warn = FALSE)
@@ -624,7 +624,7 @@ try_purl_or_tangle <- function(input, output, quiet, ...) {
 checkVigClassUsage <- function(.BiocPackage) {
     vigfiles <- .BiocPackage$VigSources
     viglist <- structure(
-        vector("list", length(vigfiles)), .Names = basename(vigfiles)
+        vector("list", length(vigfiles)), names = basename(vigfiles)
     )
     for (vfile in vigfiles) {
         tempR <- tempfile(fileext=".R")
@@ -648,11 +648,11 @@ checkVigClassUsage <- function(.BiocPackage) {
 checkVigSessionInfo <- function(.BiocPackage) {
     vigfiles <- .BiocPackage$VigSources
     notFoundVig <- structure(
-        vector("logical", length(vigfiles)), .Names = vigfiles
+        vector("logical", length(vigfiles)), names = vigfiles
     )
     for (vfile in vigfiles) {
         pc <- structure(
-            list(parseFile(.BiocPackage, vfile)), .Names = vfile
+            list(parseFile(.BiocPackage, vfile)), names = vfile
         )
         if (nrow(pc[[vfile]])) {
             res <- findSymbolsInParsedCode(

--- a/R/findSymbols.R
+++ b/R/findSymbols.R
@@ -77,7 +77,7 @@ findSymbolsInParsedCode <-
     )
 {
     matches <- structure(vector("list", length(parsedCodeList)),
-        .Names = names(parsedCodeList))
+        names = names(parsedCodeList))
     allcombos <- expand.grid(
         tokenTypes = tokenTypes,
         symbolNames = symbolNames,
@@ -129,7 +129,7 @@ findSymbolsInRFiles <-
 {
     rfiles <- .BiocPackage$RSources
     parsedCodes <- lapply(
-        structure(rfiles, .Names = rfiles), parseFile,
+        structure(rfiles, names = rfiles), parseFile,
         .BiocPackage = .BiocPackage
     )
     msg_res <- findSymbolsInParsedCode(
@@ -161,7 +161,7 @@ findSymbolsInVignettes <-
 {
     vigfiles <- .BiocPackage$VigSources
     shortnames <- .getDirFiles(vigfiles)
-    viglist <- structure(vector("list", length(vigfiles)), .Names = shortnames)
+    viglist <- structure(vector("list", length(vigfiles)), names = shortnames)
     for (i in seq_along(vigfiles)) {
         shortName <- shortnames[i]
         tempR <- tempfile(fileext=".R")

--- a/R/parseFiles.R
+++ b/R/parseFiles.R
@@ -30,7 +30,7 @@ parseFiles <- function(.BiocPackage)
     manfiles <- .BiocPackage$manSources
     vigfiles <- .BiocPackage$VigSources
     files <- c(rfiles, manfiles, vigfiles)
-    parsedCode <- structure(vector("list", length(files)), .Names = files)
+    parsedCode <- structure(vector("list", length(files)), names = files)
     for (file in files)
     {
         df <- parseFile(.BiocPackage, file)

--- a/R/util.R
+++ b/R/util.R
@@ -31,7 +31,7 @@ handleCondition <-
             "<Internal> Designate input with 'warning', 'error', or 'note'."
         )
     cl <- sys.call(sys.parent(n = nframe))[[1L]]
-    ml <- structure(msg, .Names = tail(as.character(cl), 1L))
+    ml <- structure(msg, names = tail(as.character(cl), 1L))
     .BiocCheck$add(
         ml,
         condition = condition,


### PR DESCRIPTION
The latter returns the following warning:

> Warning in structure(msg, .Names = tail(as.character(cl), 1L)) :
>   Replacing special names ‘.Names’ is deprecated; use ‘names’ instead.

Introduced in https://github.com/r-devel/r-svn/commit/ec9dbaed71a6b34de3a08b30674bd08896337286.

Should this get a NEWS bullet?

As an aside, I would find `setNames()` slightly more readable so if you agree, I'm happy to add a new commit for that.